### PR TITLE
Adds assertions and prerequisites step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@ This application provides a generic toolbox that is meant to abstract generic in
 
 Scripts are written using an ansible-like yaml format. In general the structure of the scripts are as follows
 ```
+prerequisites:
+    - <script steps appear here>
 steps:
     - <script steps appear here>
 rollback:
     - <steps to rollback appear here>
 ```
-There are two top level sequences, `steps` and `rollback`. 
+There are three top level sequences, `prerequisites`, `steps` and `rollback`.
 The entries in `steps` specify the actual steps that will be run when the application is invoked, while the (optional) `rollback` sequence defines steps that are run if any of the steps in `steps` sequence fail.
 Any steps that can appear in the `steps` sequence can appear in `rollback`.
+The `prerequisites` array is optional and will play any steps that can appear in `steps` except that if any of these fail,
+the task will exit and the rollback steps *will not be run*. 
+`prerequisites` is a very good place to run any *assertions* (below) to ensure that the task can and should be run on the target environment.  
+
 The kinds of steps supported are described below.
 
 ---
@@ -41,6 +47,34 @@ Second:
 Advanced tasks are potentially very destructive and should be used _very carefully_.
 
 ***
+
+## Assertions
+
+Assertions are simple boolean checks that will throw an exception if they are not met.
+With the `assertTrue` and `assertFalse` fields you are able to specify the conditions under which an assertion will pass.
+Currently, the toolbox supports the following assertions.
+
+# currentopenshift
+
+This assertion will allow you to test whether the target environment is _currently_ on a particular deploytarget.
+
+For example, if we wanted to assert that a particular environment's deploytarget should be 3, we could use
+
+```
+  - name: Current openshift should be 3
+    assertTrue: currentopenshift
+    target: 3
+```
+
+If we wanted to assert that it _shouldn't_ currently be 3, we could do the following.
+
+```
+  - name: Current openshift should NOT be 3
+    assertFalse: currentopenshift
+    target: 3
+```
+
+Typically you would run this as part of the `prerequisites` step to ensure you aren't going to apply a set of transformations in the wrong namespace.
 
 ## Step types
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -45,7 +45,25 @@ class RoboFile extends \Robo\Tasks
           "LAGOON_GIT_BRANCH"
         );
 
+        //Here we add a pre-runner set of steps - this can be used for assertions
+        //and does _not_ trigger a rollback
+
         try {
+            if(!empty($migration['prerequisites'])) {
+                printf("Found prerequisite steps - will run with no rollback\n\n");
+                $args->steps = $migration['prerequisites'];
+                $runner = new \Migrator\Runner($args);
+                $runner->run();
+            } else {
+                printf("No prerequisites found - proceeding to run main steps\n\n");
+            }
+        } catch (\Exception $ex) {
+            printf("Prerequistes failed with the following message: %s \n\n exiting", $ex->getMessage());
+            exit(1);
+        }
+
+        try {
+            $args->steps = $migration['steps'];
             $runner = new \Migrator\Runner($args);
             $runner->run();
         } catch (\Exception $ex) {

--- a/src/Assert/AssertInterface.php
+++ b/src/Assert/AssertInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Migrator\Assert;
+
+interface AssertInterface
+{
+
+    public function assert(array $args): bool;
+
+}

--- a/src/Assert/AssertParent.php
+++ b/src/Assert/AssertParent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Migrator\Assert;
+
+use Migrator\LagoonUtilityBelt;
+use Migrator\LoggerTrait;
+use Migrator\RunnerArgs;
+use Migrator\UtilityBelt;
+
+abstract class AssertParent implements AssertInterface
+{
+    use LoggerTrait;
+    protected $cluster;
+    protected $namespace;
+    protected $utilityBelt;
+    protected $token;
+    protected $args;
+
+    public function __construct(RunnerArgs $args)
+    {
+        $this->cluster = $args->cluster;
+        $this->namespace = $args->namespace;
+        $this->token = $args->token;
+        $this->args = $args;
+        $this->utilityBelt = new LagoonUtilityBelt($this->cluster, $this->namespace, $args->sshKey);
+    }
+
+    abstract public function assert(array $args): bool;
+
+}

--- a/src/Assert/Assertcurrentopenshift.php
+++ b/src/Assert/Assertcurrentopenshift.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Migrator\Assert;
+
+class Assertcurrentopenshift extends AssertParent
+{
+
+    public function assert(array $args): bool
+    {
+        if(empty($args['target'])) {
+            throw new \Exception("assertcurrentopenshift requires a 'target' field");
+        }
+        //Get current environment information
+        $envdeets = $this->utilityBelt->getEnvironmentDetails($this->args->project, $this->args->environment);
+        return $args['target'] == $envdeets['openshift']->id;
+    }
+
+}

--- a/src/Assert/Readme.md
+++ b/src/Assert/Readme.md
@@ -1,0 +1,8 @@
+# Assertions
+
+This folder contains all the basic assertions required for Advanced Tasks.
+
+Essentially an assertion will simply assert whether a particular fact about an environment/project is either true or false.
+We use assertions as guards against, for example, running tasks in the wrong environment,
+or checking that the steps we've run have been properly effected.
+

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -16,8 +16,7 @@ class Runner
     protected $args;
 
     public function __construct(RunnerArgs $args
-    )
-    {
+    ) {
         $this->steps = $args->steps;
         $this->cluster = $args->cluster;
         $this->namespace = $args->namespace;
@@ -27,7 +26,10 @@ class Runner
 
     public function __get($name)
     {
-        if(property_exists($this->args, $name) && !empty($this->args->{$name})) {
+        if (property_exists(
+            $this->args,
+            $name
+          ) && !empty($this->args->{$name})) {
             return $this->args->{$name};
         }
 
@@ -37,20 +39,80 @@ class Runner
     public function run()
     {
         foreach ($this->steps as $step) {
-            if (empty($step['type'])) {
-                throw new \Exception("Step does not exist");
+            //determine if this is a step or an assertion
+            if (!empty($step['assertTrue']) || !empty($step['assertFalse'])) {
+                $this->runAssertion($step);
+            } else {
+                $this->runStep($step);
             }
-            //here we autoload up the steps
-            $classname = "Migrator\\Step\\" . ucfirst(
-                strtolower($step['type'])
-              );
-            if (!class_exists($classname)) {
-                throw new \Exception("Class '{$classname} does not exist");
-            }
-
-            $stepObj = new $classname($this->args);
-            $stepObj->run($step);
         }
+    }
+
+    /**
+     * @param $step
+     *
+     * @return void
+     * @throws \Exception
+     */
+    protected function runAssertion($step)
+    {
+        if (!empty($step['assertTrue']) && !empty($step['assertFalse'])) {
+            throw new \Exception(
+              "An assertion cannot be true and false at the same time - found both assertTrue and assertFalse"
+            );
+        }
+
+        $expectedAssertionResult = true;
+        $assertion = null;
+        if (!empty($step['assertTrue'])) {
+            $assertion = sprintf("Assert%s", strtolower($step['assertTrue']));
+            $expectedAssertionResult = true;
+        } else {
+            $assertion = sprintf("Assert%s", strtolower($step['assertFalse']));
+            $expectedAssertionResult = false;
+        }
+
+
+        //here we autoload up the steps
+        $classname = "Migrator\\Assert\\" . $assertion;
+
+        if (!class_exists($classname)) {
+            throw new \Exception("Class '{$classname} does not exist - could not load assertion");
+        }
+
+        $stepObj = new $classname($this->args);
+        $assertionResult = $stepObj->assert($step);
+
+        if ($assertionResult != $expectedAssertionResult) {
+            $expectedAssertionResultString = $expectedAssertionResult ? 'TRUE' : 'FALSE';
+            $assertionResultString = $assertionResult ? 'TRUE' : 'FALSE';
+            throw new \Exception("Assertion {$step['name']} failed - expected {$expectedAssertionResultString} got $assertionResultString");
+        }
+    }
+
+    /**
+     * @param $step
+     *
+     * @return void
+     * @throws \Exception
+     */
+    protected function runStep($step)
+    {
+        if (empty($step['type'])) {
+            throw new \Exception(
+              "Step to run is not defined - ensure there is a 'step' field"
+            );
+        }
+        //here we autoload up the steps
+        $classname = "Migrator\\Step\\" . ucfirst(
+            strtolower($step['type'])
+          );
+        if (!class_exists($classname)) {
+            throw new \Exception("Class '{$classname} does not exist");
+        }
+
+        $stepObj = new $classname($this->args);
+        $stepObj->run($step);
     }
 
 }


### PR DESCRIPTION
This PR introduces some basic environment assertions (checking whether an environment's openshift is a particular id, and checking whether an environment's "type" is "production" or "development")

It also introduces a "prerequisites" step that allows one to run steps which, when failed, don't trigger the rollback, but merely exit the application.

closes #2 